### PR TITLE
Added voice/fax-parsing for WHMCS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 InterNetworX Registrar Module for WHMCS<br>
-Version 2.0.1 (2015-12-16)
+Version 2.0.2 (2016-02-08)
 ____________________________________________________________________________________
 
 #SUPPORTED FEATURES:

--- a/modules/registrars/internetworx/internetworx.php
+++ b/modules/registrars/internetworx/internetworx.php
@@ -273,7 +273,8 @@ function internetworx_SaveContactDetails($params) {
 			$pContact["fax"] = $params["contactdetails"][$typeName]["Fax Number"];
 			$pContact["email"] = $params["contactdetails"][$typeName]["Email"];
 			$pContact["remarks"] = $params["contactdetails"][$typeName]["Notes"];
-
+			$pContact["extData"] = array('PARSE-VOICE' => true, 'PARSE-FAX' => true);
+			
 			if ($countContactIds[$contactIds[$type]]>1) {
 				// create contact
 				$pContact['type'] = 'PERSON';

--- a/modules/registrars/internetworx/internetworx.php
+++ b/modules/registrars/internetworx/internetworx.php
@@ -360,6 +360,7 @@ function internetworx_RegisterDomain($params) {
 	if (isset($params["notes"]) && !empty($params["notes"])) {
 		$pRegistrant['remarks'] = $params["notes"];
 	}
+	$pRegistrant['extData'] = array('PARSE-VOICE' => true, 'PARSE-FAX' => true);
 	
 	// do registrant create command 
 	$response = $domrobot->call('contact','create',$pRegistrant);
@@ -391,6 +392,7 @@ function internetworx_RegisterDomain($params) {
 	if (isset($params["adminnotes"]) && !empty($params["adminnotes"])) {
 		$pAdmin['remarks'] = $params["adminnotes"];
 	}
+	$pAdmin['extData'] = array('PARSE-VOICE' => true, 'PARSE-FAX' => true);
 	
 	// do admin create command
 	$response = $domrobot->call('contact','create',$pAdmin);
@@ -486,6 +488,7 @@ function internetworx_TransferDomain($params) {
 	if (isset($params["notes"]) && !empty($params["notes"])) {
 		$pRegistrant['remarks'] = $params["notes"];
 	}
+	$pRegistrant['extData'] = array('PARSE-VOICE' => true, 'PARSE-FAX' => true);
 	
 	// do registrant create command 
 	$response = $domrobot->call('contact','create',$pRegistrant);
@@ -517,6 +520,7 @@ function internetworx_TransferDomain($params) {
 	if (isset($params["adminnotes"]) && !empty($params["adminnotes"])) {
 		$pAdmin['remarks'] = $params["adminnotes"];
 	}
+	$pAdmin['extData'] = array('PARSE-VOICE' => true, 'PARSE-FAX' => true);
 	
 	// do admin create command
 	$response = $domrobot->call('contact','create',$pAdmin);


### PR DESCRIPTION
The plugin now sends a flag with the contact-based API requests to automatically parse the voice- and faxnumbers to the correct format.